### PR TITLE
[ ADD ] image-slider를 동적으로 생성하고, 이를 이동시키는 버튼을 구현하라

### DIFF
--- a/image-slider-react/src/components/Main.jsx
+++ b/image-slider-react/src/components/Main.jsx
@@ -1,62 +1,81 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
-import { FiArrowLeft } from "react-icons/fi";
-import { FiArrowRight } from "react-icons/fi";
+import { FiArrowLeft, FiArrowRight } from "react-icons/fi";
+import { FaPlay } from "react-icons/fa";
+import { GiPauseButton } from "react-icons/gi";
+import { ImgColor, ImgList } from "../unit/ImgInfo";
 
 function Main() {
+  const [autoPlay, setAutoPlay] = useState(true);
+  const [movePx, setMovePx] = useState(0);
+
+  const handleMovePrev = () => {
+    if (movePx === 0) {
+      setMovePx(-((ImgColor.length - 1) * 500));
+      return;
+    }
+    setMovePx(movePx + 500);
+  };
+
+  const handleMoveNext = () => {
+    if (movePx === -((ImgColor.length - 1) * 500)) {
+      setMovePx(0);
+      return;
+    }
+    setMovePx(movePx - 500);
+  };
+
+  const handleAutoPlay = () => {
+    console.log("autoplay");
+    setAutoPlay(!autoPlay);
+  };
+
   return (
     <>
       <SliderWrap>
-        <SliderList>
-          <li>
-            <img src="./img/red.jpeg" />
-          </li>
-          <li>
-            <img src="./img/orange.jpeg" />
-          </li>
-          <li>
-            <img src="./img/yellow.jpeg" />
-          </li>
-          <li>
-            <img src="./img/blue.jpeg" />
-          </li>
-          <li>
-            <img src="./img/violet.jpeg" />
-          </li>
-          <li>
-            <img src="./img/indigo.jpeg" />
-          </li>
+        <SliderList movePx={movePx}>
+          <ImgList />
         </SliderList>
         <ButtonBox>
-          <BtnPrev>
+          <BtnPrev onClick={handleMovePrev}>
             <FiArrowLeft />
           </BtnPrev>
-          <BtnNext>
+          <BtnNext onClick={handleMoveNext}>
             <FiArrowRight />
           </BtnNext>
         </ButtonBox>
+        <IndicatorBox>
+          <ul>
+            {ImgColor.map((el, idx) => (
+              <li key={idx}></li>
+            ))}
+          </ul>
+        </IndicatorBox>
+        <AutoBox onClick={handleAutoPlay}>
+          {autoPlay ? <GiPauseButton /> : <FaPlay />}
+        </AutoBox>
       </SliderWrap>
     </>
   );
 }
-
+// 버튼을 클릭하면 SliderList의 left값을 -500px씩 이동한다
 const SliderWrap = styled.div`
-  border: 1px solid black;
-  list-style: none;
   width: 500px;
-  height: 300px;
-  margin: 0 auto;
+  height: 350px;
+  margin: 50px auto;
   position: relative;
+  list-style: none;
+  overflow: hidden;
 `;
 const SliderList = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
   position: absolute;
-  left: 0;
+  left: ${(props) => `${props.movePx}px`};
   img {
     width: 500px;
-    margin: 50px 0;
+    height: 100%;
     z-index: 1;
   }
 `;
@@ -87,10 +106,41 @@ const ButtonBox = styled.div`
 
 const BtnPrev = styled.button`
   border-radius: 0 8px 8px 0;
-  /* left: 50px; */
 `;
 const BtnNext = styled.button`
   border-radius: 8px 0 0 8px;
+`;
+
+const IndicatorBox = styled.div`
+  position: absolute;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  & ul {
+    display: flex;
+    margin: 0;
+    padding: 0;
+    & li {
+      width: 15px;
+      height: 15px;
+      list-style: none;
+      cursor: pointer;
+      margin: 0 5px;
+      background-color: white;
+      opacity: 0.5;
+      border-radius: 8px;
+      :active {
+        opacity: 1;
+      }
+    }
+  }
+`;
+const AutoBox = styled.div`
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+  color: white;
+  cursor: pointer;
 `;
 
 export default Main;

--- a/image-slider-react/src/unit/ImgInfo.js
+++ b/image-slider-react/src/unit/ImgInfo.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+export const ImgColor = [
+  "red",
+  "orange",
+  "yellow",
+  "orange",
+  "green",
+  "blue",
+  "violet",
+  "green",
+  "indigo",
+];
+
+export const ImgList = () => {
+  const imgList = ImgColor.map((el, idx) => (
+    <li key={idx}>
+      <img src={`./img/${el}.jpeg`}/>
+    </li>
+  ));
+  return <>{imgList}</>;
+};


### PR DESCRIPTION
- 인디케이터를 직접 li태그로 작성하지 않고, img파일 갯수에 따라 동적으로 생성할 수 있도록 함
- slider에 들어갈 img파일을 고정으로 두지 않고 동적으로 생성할 수 있도록 작성함. 파일을 추가하고 imgColor 배열에 값을 추가하면 ImgList를 map으로 li를 생성함.
- prev, next버튼을 클릭하면 img의 left이동값을 변화시킴
- useState에 이동값을 저장해두고, 버튼을 클릭할 때마다 img넓이만큼 이동하도록 함
- 마지막과 처음의 img에는 slide위치를 확인한 뒤, useState에 처음값, 마지막값을 주어 무한 반복할 수 있도록 함