### PR TITLE
[ ADD ] date태그에 요일별로 style을 추가하였다

### DIFF
--- a/date-picker-react/src/App.css
+++ b/date-picker-react/src/App.css
@@ -85,6 +85,12 @@ h1 {
   justify-content: center;
   align-items: center;
 }
+.days .sun {
+  color: red;
+}
+.days .sat {
+  color: blue;
+}
 .calendar .dates {
   display: grid;
   grid-template-columns: repeat(7, 1fr);

--- a/date-picker-react/src/App.jsx
+++ b/date-picker-react/src/App.jsx
@@ -11,36 +11,60 @@ function App() {
     date: data.getDate(),
   });
 
+  // 콘솔 출력이 2번되는 이유눈 렌더링 (1), curDate-update되서 렌더링(2)
+  // 이부분.음 뭔가 처리해줘야할듯
+  // 렌더링이 2번되니까, 1번은 color안된거 2번재는 color바뀐거 . 첫번재꺼 안보여줄 순 없?
   useEffect(() => {
     updateCalendar();
   }, [curDate]);
 
-  const [dateTagList, setDateTagList] = useState();
-  const gridColumnStart = new Date(curDate.year, curDate.month, 1).getDay() + 1;
-  const firstGridDateStyle = { gridColumnStart: gridColumnStart };
+  const isSunday = (year, month, day) => {
+    return new Date(year, month, day).getDay() === 0;
+  };
 
-  const numberDate = new Date(curDate.year, curDate.month + 1, 0).getDate();
+  const isSaturday = (year, month, day) => {
+    return new Date(year, month, day).getDay() === 6;
+  };
+
+  // 달력 생성
   const updateCalendar = () => {
-    const dateTag = [];
+    const calendarList = [];
+    const numberDate = new Date(curDate.year, curDate.month + 1, 0).getDate();
+
+    // month 1일의 시작 grid-style
+    const gridColumnStart =
+      new Date(curDate.year, curDate.month, 1).getDay() + 1;
+    const firstGridDateStyle = { gridColumnStart: gridColumnStart };
+
     for (let i = 1; i <= numberDate; i++) {
+      // 토, 일요일 color
+      let cellStyle = {};
+      if (isSunday(curDate.year, curDate.month, i)) {
+        cellStyle.color = "red";
+      }
+
+      if (isSaturday(curDate.year, curDate.month, i)) {
+        cellStyle.color = "blue";
+      }
+
       i === 1
-        ? dateTag.push(
-            <p key={1} className="date" style={firstGridDateStyle}>
+        ? calendarList.push(
+            <p
+              key={1}
+              className="date"
+              style={{ ...firstGridDateStyle, ...cellStyle }}
+            >
               {1}
             </p>
           )
-        : dateTag.push(
-            <p key={i} className="date">
+        : calendarList.push(
+            <p key={i} className="date" style={cellStyle}>
               {i}
             </p>
           );
     }
-    setDateTagList(dateTag);
+    return calendarList;
   };
-
-  console.log("gridColumnStart-", gridColumnStart);
-  console.log("numberDate-", numberDate);
-  console.log(curDate);
 
   const movePrevMonth = () => {
     setCurDate((state) => {
@@ -72,7 +96,7 @@ function App() {
           className="dateBox"
           onClick={() => {
             setShowCalendar(!showCalendar);
-            updateCalendar();
+            // updateCalendar();
           }}
         >
           {`${curDate.year}년 ${curDate.month + 1}월 ${curDate.date}일`}
@@ -89,15 +113,15 @@ function App() {
               </button>
             </div>
             <div className="days">
-              <p className="day">SUN</p>
+              <p className="day sun">SUN</p>
               <p className="day">MON</p>
               <p className="day">TUE</p>
               <p className="day">WED</p>
               <p className="day">THU</p>
               <p className="day">FRI</p>
-              <p className="day">SAT</p>
+              <p className="day sat">SAT</p>
             </div>
-            <div className="dates">{dateTagList}</div>
+            <div className="dates">{updateCalendar()}</div>
           </div>
         )}
       </div>

--- a/date-picker-react/src/GPT.jsx
+++ b/date-picker-react/src/GPT.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+
+const Calendar = () => {
+  const [year, setYear] = useState(new Date().getFullYear());
+  const [month, setMonth] = useState(new Date().getMonth());
+
+  const getDaysInMonth = (year, month) => {
+    return new Date(year, month + 1, 0).getDate();
+  };
+
+  const getFirstDayOfMonth = (year, month) => {
+    return new Date(year, month, 1).getDay();
+  };
+
+  const isSunday = (year, month, day) => {
+    return new Date(year, month, day).getDay() === 0;
+  };
+
+  const isSaturday = (year, month, day) => {
+    return new Date(year, month, day).getDay() === 6;
+  };
+
+  const renderCalendar = () => {
+    const totalDays = getDaysInMonth(year, month);
+    const firstDay = getFirstDayOfMonth(year, month);
+
+    const calendar = [];
+
+    // Render blank cells for days before the first day of the month
+    for (let i = 0; i < firstDay; i++) {
+      calendar.push(<div key={`blank-${i}`} className="blank-cell"></div>);
+    }
+
+    // Render cells for each day of the month
+    for (let day = 1; day <= totalDays; day++) {
+      let cellStyle = {};
+
+      if (isSunday(year, month, day)) {
+        cellStyle.color = "red";
+      }
+
+      if (isSaturday(year, month, day)) {
+        cellStyle.color = "blue";
+      }
+
+      calendar.push(
+        <div key={`day-${day}`} className="calendar-cell" style={cellStyle}>
+          {day}
+        </div>
+      );
+    }
+
+    return calendar;
+  };
+
+  return (
+    <div className="calendar">
+      <h2>{`${year}년 ${month + 1}월`}</h2>
+      <div className="calendar-grid">
+        <div className="weekday-header">일</div>
+        <div className="weekday-header">월</div>
+        <div className="weekday-header">화</div>
+        <div className="weekday-header">수</div>
+        <div className="weekday-header">목</div>
+        <div className="weekday-header">금</div>
+        <div className="weekday-header">토</div>
+        {renderCalendar()}
+      </div>
+    </div>
+  );
+};
+
+export default Calendar;

--- a/date-picker-react/src/index.js
+++ b/date-picker-react/src/index.js
@@ -1,10 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import Calendar from "./GPT";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   // <React.StrictMode>
-  <App />
+  <>
+    <App />
+    {/* <Calendar /> */}
+  </>
   // </React.StrictMode>
 );


### PR DESCRIPTION
- 리액트에서는 노드 수정을 지양하니, 태그를 생성할 때 JSX로 style 을 추가해주는 방법을 선택했다. 
- chatGPT의 도움을 받아 요일을 구하는 함수를 작성해 style을 구현하였다. ( new Date() 메서드의 getDay()를 활용)
- date의 내용을 담고 있는 p태그에 inline-style방식으로 style을 추가하였다 